### PR TITLE
Use Statsd#time instead of #timing

### DIFF
--- a/lib/rack/graphite.rb
+++ b/lib/rack/graphite.rb
@@ -19,7 +19,7 @@ module Rack
       metric = path_to_graphite(method, path)
 
       status, headers, body = nil
-      Lookout::Statsd.instance.timing(metric) do
+      Lookout::Statsd.instance.time(metric) do
         status, headers, body = @app.call(env)
       end
       Lookout::Statsd.instance.increment("#{metric}.response.#{status}")

--- a/lib/rack/graphite/version.rb
+++ b/lib/rack/graphite/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class Graphite
-    VERSION = '1.3.0'
+    VERSION = '1.4.0'
   end
 end

--- a/rack-graphite.gemspec
+++ b/rack-graphite.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
 
-  spec.add_dependency 'lookout-statsd', '~> 3.0'
+  spec.add_dependency 'lookout-statsd', '~> 3.1'
 end

--- a/spec/graphite_spec.rb
+++ b/spec/graphite_spec.rb
@@ -83,8 +83,8 @@ describe Rack::Graphite do
     subject(:middleware) { described_class.new(app) }
 
     before :each do
-      # Stub out timing by default to and just yield
-      statsd.stub(:timing).and_yield
+      # Stub out time by default to and just yield
+      statsd.stub(:time).and_yield
       statsd.stub(:increment)
     end
 
@@ -109,7 +109,7 @@ describe Rack::Graphite do
       end
 
       it 'should invoke a timer' do
-        statsd.should_receive(:timing)
+        statsd.should_receive(:time)
         middleware.call({})
       end
     end
@@ -122,7 +122,7 @@ describe Rack::Graphite do
 
     context 'with a root request' do
       before :each do
-        statsd.should_receive(:timing).with('requests.get.root').and_yield
+        statsd.should_receive(:time).with('requests.get.root').and_yield
         statsd.should_receive(:increment).with('requests.get.root.response.200')
         get '/'
       end
@@ -131,7 +131,7 @@ describe Rack::Graphite do
 
     context 'with a request with query params' do
       before :each do
-        statsd.should_receive(:timing).with('requests.get.onelevel').and_yield
+        statsd.should_receive(:time).with('requests.get.onelevel').and_yield
         statsd.should_receive(:increment).with('requests.get.onelevel.response.200')
         get '/onelevel?q=foo'
       end
@@ -140,7 +140,7 @@ describe Rack::Graphite do
 
     context 'with a PUT request' do
       before :each do
-        statsd.should_receive(:timing).with('requests.put.onelevel').and_yield
+        statsd.should_receive(:time).with('requests.put.onelevel').and_yield
         statsd.should_receive(:increment).with('requests.put.onelevel.response.200')
         put '/onelevel'
       end


### PR DESCRIPTION
Lookout-statsd used #timing where other statsd's use #time, but
lookout-statsd now has #time as well, so use that for compatibility.