### PR TITLE
Replace all GUIDs in paths, not just /GUID

### DIFF
--- a/lib/rack/graphite.rb
+++ b/lib/rack/graphite.rb
@@ -5,8 +5,8 @@ module Rack
     PREFIX = 'requests'
     ID_REGEXP = %r{/\d+(/|$)} # Handle /123/ or /123
     ID_REPLACEMENT = '/id\1'.freeze
-    GUID_REGEXP = %r{/\h{8}-\h{4}-\h{4}-\h{4}-\h{12}(/|$)} # Handle /GUID/ or /GUID
-    GUID_REPLACEMENT = '/guid\1'.freeze
+    GUID_REGEXP = %r{\h{8}-\h{4}-\h{4}-\h{4}-\h{12}(/|$)} # Handle GUID/ or GUID
+    GUID_REPLACEMENT = 'guid\1'.freeze
 
     def initialize(app, options={})
       @app = app

--- a/lib/rack/graphite.rb
+++ b/lib/rack/graphite.rb
@@ -5,8 +5,8 @@ module Rack
     PREFIX = 'requests'
     ID_REGEXP = %r{/\d+(/|$)} # Handle /123/ or /123
     ID_REPLACEMENT = '/id\1'.freeze
-    GUID_REGEXP = %r{\h{8}-\h{4}-\h{4}-\h{4}-\h{12}(/|$)} # Handle GUID/ or GUID
-    GUID_REPLACEMENT = 'guid\1'.freeze
+    GUID_REGEXP = %r{\h{8}-\h{4}-\h{4}-\h{4}-\h{12}} # Handle *GUID*
+    GUID_REPLACEMENT = 'guid'.freeze
 
     def initialize(app, options={})
       @app = app

--- a/lib/rack/graphite/version.rb
+++ b/lib/rack/graphite/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class Graphite
-    VERSION = '1.4.1'
+    VERSION = '1.5.0'
   end
 end

--- a/spec/graphite_spec.rb
+++ b/spec/graphite_spec.rb
@@ -57,9 +57,14 @@ describe Rack::Graphite do
         it { should eql('requests.get.one.v1.two') }
       end
 
-      context 'with a guid embedded in a path' do
+      context 'with a guid embedded in a path with slashes' do
         let(:path) { "/one/#{guid}/five" }
         it { should eql('requests.get.one.guid.five') }
+      end
+
+      context 'with a guid embedded in a path without slashes' do
+        let(:path) { "/one_#{guid}/five" }
+        it { should eql('requests.get.one_guid.five') }
       end
 
       context 'with a path ending in a guid' do

--- a/spec/graphite_spec.rb
+++ b/spec/graphite_spec.rb
@@ -63,8 +63,8 @@ describe Rack::Graphite do
       end
 
       context 'with a guid embedded in a path without slashes' do
-        let(:path) { "/one_#{guid}/five" }
-        it { should eql('requests.get.one_guid.five') }
+        let(:path) { "/one_#{guid}_one/five" }
+        it { should eql('requests.get.one_guid_one.five') }
       end
 
       context 'with a path ending in a guid' do


### PR DESCRIPTION
The GUID format is sufficiently unique that we should always strip it out.