### PR TITLE
Added lambda filter to initialization options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,24 @@ By default this will log metrics such as:
         'Hello!'
       end
     end
+    
+Filter options have been added as an initialization parameter allowing 
+specific requests not be processed by [lookout-statsd](https://github.com/lookout/statsd). 
+The filter option is assumed to be a list of lambda functions that will be
+applied to rack requests. An example of initializing rack-graphite with a
+filter option is provided below:
+
+
+    require 'rack/graphite'
+
+    class MyApp < Sinatra::Base
+      use Rack::Graphite, { filters: [ lambda{|env| env['PATH_INFO'].include? 'dont_log'} ] }
+
+      get '/' do
+        'Hello!'
+      end
+      
+      get "/dont_log/#{random_number}" do
+        'Causes too many metrics.'
+      end
+    end

--- a/lib/rack/graphite.rb
+++ b/lib/rack/graphite.rb
@@ -11,9 +11,16 @@ module Rack
     def initialize(app, options={})
       @app = app
       @prefix = options[:prefix] || PREFIX
+      @filters = options[:filters] || []
     end
 
     def call(env)
+      @filters.each do |filter|
+        if filter.call(env)
+          return @app.call(env)
+        end
+      end
+
       path = env['PATH_INFO'] || '/'
       method = env['REQUEST_METHOD'] || 'GET'
       metric = path_to_graphite(method, path)

--- a/lib/rack/graphite/version.rb
+++ b/lib/rack/graphite/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class Graphite
-    VERSION = '1.5.1'
+    VERSION = '1.6.0'
   end
 end

--- a/lib/rack/graphite/version.rb
+++ b/lib/rack/graphite/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class Graphite
-    VERSION = '1.5.0'
+    VERSION = '1.5.1'
   end
 end

--- a/spec/graphite_spec.rb
+++ b/spec/graphite_spec.rb
@@ -117,6 +117,17 @@ describe Rack::Graphite do
         statsd.should_receive(:time)
         middleware.call({})
       end
+
+      context 'with a filtered request' do
+        let(:middleware) { described_class.new(app, {filters: [ lambda {|req| req['PATH_INFO'].include? 'onelevel'} ]}) }
+        let(:env) { {'PATH_INFO' => '/onelevel'} }
+
+        it 'does not invoke Lookout::Statsd' do
+          statsd.should_not_receive(:time)
+          statsd.should_not_receive(:increment)
+          expect(middleware.call(env)).to eql([status, headers, response])
+        end
+      end
     end
   end
 


### PR DESCRIPTION
These modifications are intended to allow projects to selectively filter certain paths and avoid creating excessive metrics.